### PR TITLE
fix(cmake): allow symbols to be built as a subdirectory by setting BA…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(lam::symbols ALIAS symbols)
 target_sources(symbols PUBLIC
         FILE_SET CXX_MODULES
         TYPE CXX_MODULES
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
         FILES 
             src/symbols.cppm
             src/symbols-traits.cppm


### PR DESCRIPTION
…SE_DIRS